### PR TITLE
add ability to call against a certain block

### DIFF
--- a/src/Network/Ethereum/Contract/Method.hs
+++ b/src/Network/Ethereum/Contract/Method.hs
@@ -18,7 +18,6 @@ module Network.Ethereum.Contract.Method (
   , sendTx
   ) where
 
-import Data.Aeson (toJSON)
 import           Control.Monad.Catch               (throwM)
 import           Control.Monad.Reader
 import           Data.Monoid                       ((<>))
@@ -76,9 +75,7 @@ call :: (Method a, ABIGet b)
 call call' mode (dat :: a) = do
     let sel = selector (Proxy :: Proxy a)
         c = (call' { callData = Just $ sel <> encode dat })
-    liftIO $ print $ show $ toJSON c
     res <- Eth.call c mode
-    liftIO $ print res
     case decode res of
         Left e  -> throwM $ ParserFail $ "Unable to parse response: " ++ e
         Right x -> return x

--- a/test-support/abis/ERC20.json
+++ b/test-support/abis/ERC20.json
@@ -1,0 +1,110 @@
+[
+	{
+		"constant": true,
+		"inputs": [],
+		"name": "totalSupply",
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"name": "",
+				"type": "address"
+			}
+		],
+		"name": "balances",
+		"outputs": [
+			{
+				"name": "",
+				"type": "uint256"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": true,
+		"inputs": [
+			{
+				"name": "_owner",
+				"type": "address"
+			}
+		],
+		"name": "balanceOf",
+		"outputs": [
+			{
+				"name": "balance",
+				"type": "uint256"
+			}
+		],
+		"payable": false,
+		"stateMutability": "view",
+		"type": "function"
+	},
+	{
+		"constant": false,
+		"inputs": [
+			{
+				"name": "_to",
+				"type": "address"
+			},
+			{
+				"name": "_value",
+				"type": "uint256"
+			}
+		],
+		"name": "transfer",
+		"outputs": [
+			{
+				"name": "",
+				"type": "bool"
+			}
+		],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "function"
+	},
+	{
+		"inputs": [
+			{
+				"name": "owner",
+				"type": "address"
+			}
+		],
+		"payable": false,
+		"stateMutability": "nonpayable",
+		"type": "constructor"
+	},
+	{
+		"anonymous": false,
+		"inputs": [
+			{
+				"indexed": true,
+				"name": "to",
+				"type": "address"
+			},
+			{
+				"indexed": true,
+				"name": "from",
+				"type": "address"
+			},
+			{
+				"indexed": false,
+				"name": "value",
+				"type": "uint256"
+			}
+		],
+		"name": "Transfer",
+		"type": "event"
+	}
+]

--- a/test-support/bower.json
+++ b/test-support/bower.json
@@ -7,6 +7,6 @@
     "output"
   ],
   "devDependencies": {
-    "purescript-chanterelle": "f-o-a-m/chanterelle#v0.10.0"
+    "purescript-chanterelle": "f-o-a-m/chanterelle#77ed0a2a561c9c53fcbe8879db47a19ecefbf3ff"
   }
 }

--- a/test-support/chanterelle.json
+++ b/test-support/chanterelle.json
@@ -7,6 +7,7 @@
                , "SimpleStorage"
                ],
     "dependencies": [],
+    "extra-abis": "abis",
     "libraries": {
     },
     "purescript-generator": {

--- a/test/Network/Ethereum/Web3/Test/ComplexStorageSpec.hs
+++ b/test/Network/Ethereum/Web3/Test/ComplexStorageSpec.hs
@@ -37,7 +37,7 @@ import           Network.Ethereum.Contract.TH
 import           Network.Ethereum.Web3            hiding (convert)
 import qualified Network.Ethereum.Web3.Eth        as Eth
 import           Network.Ethereum.Web3.Test.Utils
-import           Network.Ethereum.Web3.Types      (Call (..), Filter (..))
+import           Network.Ethereum.Web3.Types
 import           System.IO.Unsafe                 (unsafePerformIO)
 
 
@@ -102,15 +102,15 @@ complexStorageSpec = do
             let theCall = callFromTo primaryAccount contractAddress
                 runGetterCall f = runWeb3Configured (f theCall)
             -- there really has to be a better way to do this
-            uintVal'    <- runGetterCall uintVal
-            intVal'     <- runGetterCall intVal
-            boolVal'    <- runGetterCall boolVal
-            int224Val'  <- runGetterCall int224Val
-            boolsVal    <- runGetterCall $ \c -> boolVectorVal c 0
-            intsVal     <- runGetterCall $ \c -> intListVal c 0
-            stringVal'  <- runGetterCall stringVal
-            bytes16Val' <- runGetterCall bytes16Val
-            bytes2s     <- runGetterCall $ \c -> bytes2VectorListVal c 0 0
+            uintVal'    <- runWeb3Configured $ uintVal theCall Latest
+            intVal'     <- runWeb3Configured $ intVal theCall Latest
+            boolVal'    <- runWeb3Configured $ boolVal theCall Latest
+            int224Val'  <- runWeb3Configured $ int224Val theCall Latest
+            boolsVal    <- runWeb3Configured $ boolVectorVal theCall Latest 0
+            intsVal     <- runWeb3Configured $ intListVal theCall Latest 0
+            stringVal'  <- runWeb3Configured $ stringVal theCall Latest
+            bytes16Val' <- runWeb3Configured $ bytes16Val theCall Latest
+            bytes2s     <- runWeb3Configured $ bytes2VectorListVal theCall Latest 0 0
             uintVal'    `shouldBe` sUint
             intVal'     `shouldBe` sInt
             boolVal'    `shouldBe` sBool
@@ -123,6 +123,5 @@ complexStorageSpec = do
 
         it "can decode a complicated value correctly" $ \(ContractsEnv _ contractAddress, primaryAccount) -> do
             let theCall = callFromTo primaryAccount contractAddress
-                runGetterCall f = runWeb3Configured (f theCall)
-            allVals <- runGetterCall getVals
+            allVals <- runWeb3Configured $ getVals theCall Latest
             allVals `shouldBe` (sUint, sInt, sBool, sInt224, sBools, sInts, sString, sBytes16, sByte2s)

--- a/test/Network/Ethereum/Web3/Test/ERC20Spec.hs
+++ b/test/Network/Ethereum/Web3/Test/ERC20Spec.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedLists       #-}
+{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE QuasiQuotes           #-}
+{-# LANGUAGE TemplateHaskell       #-}
+
+module Network.Ethereum.Web3.Test.ERC20Spec where
+
+import           Data.Default
+import           Network.Ethereum.Contract.TH
+import           Network.Ethereum.Web3.Types
+import           Network.Ethereum.Web3
+
+
+import           Test.Hspec
+
+[abiFrom|test-support/build/contracts/abis/ERC20.json|]
+
+spec :: Spec
+spec = return ()
+
+
+getBalance :: Web3 (UIntN 256)
+getBalance = balanceOf def Latest ("0x1234567890123456789011234567890234567890" :: Address)

--- a/test/Network/Ethereum/Web3/Test/ERC20Spec.hs
+++ b/test/Network/Ethereum/Web3/Test/ERC20Spec.hs
@@ -17,7 +17,7 @@ import           Network.Ethereum.Web3
 
 import           Test.Hspec
 
-[abiFrom|test-support/build/contracts/abis/ERC20.json|]
+[abiFrom|test-support/abis/ERC20.json|]
 
 spec :: Spec
 spec = return ()

--- a/test/Network/Ethereum/Web3/Test/SimpleStorageSpec.hs
+++ b/test/Network/Ethereum/Web3/Test/SimpleStorageSpec.hs
@@ -79,7 +79,7 @@ interactions = describe "can interact with a SimpleStorage contract" $ do
         now <- runWeb3Configured Eth.blockNumber
         let later = now + 3
         awaitBlock later
-        v <- runWeb3Configured (count theCall)
+        v <- runWeb3Configured (count theCall Latest)
         v `shouldBe` theValue
 
 events :: SpecWith (ContractsEnv, Address)

--- a/web3.cabal
+++ b/web3.cabal
@@ -136,6 +136,7 @@ test-suite live
   main-is:             Spec.hs
   other-modules:       Network.Ethereum.Web3.Test.ComplexStorageSpec
                      , Network.Ethereum.Web3.Test.SimpleStorageSpec
+                     , Network.Ethereum.Web3.Test.ERC20Spec
                      , Network.Ethereum.Web3.Test.Utils
   build-depends:       base                 >4.9       && <4.12
                      , aeson


### PR DESCRIPTION
You wan't to be able to run `call`s against arbitrary blocks. Apparently this feature was never added to the quasiquoter and it always defaulted to latest

*NOTE* this is a breaking change, but it should have always been like this