### PR TITLE
use positive request ids only

### DIFF
--- a/src/Network/JsonRpc/TinyClient.hs
+++ b/src/Network/JsonRpc/TinyClient.hs
@@ -142,7 +142,7 @@ call :: (MonadIO m,
      -> [Value]
      -> m ByteString
 call m r = do
-  rid <- liftIO randomIO
+  rid <- abs <$> liftIO randomIO
   connection . encode $ Request m rid (toJSON r)
   where
     connection body = do


### PR DESCRIPTION
you know what Infura hates even more than `eth_newFilter`? that's right, negative IDs in the JSON-RPC requests! even though it's not against the JSON-RPC spec.