### PR TITLE
Bugfix/error unification

### DIFF
--- a/src/Network/JsonRpc/Exceptions.hs
+++ b/src/Network/JsonRpc/Exceptions.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Network.JsonRpc.Exceptions where
+
+import           Control.Exception              (Exception)
+import           Data.Aeson                     (Value, FromJSON(..), (.:), (.:?), withObject)
+import           Data.Text                      (Text, unpack)
+
+-- | JSON-RPC error message
+data RpcError = RpcError
+  { errCode    :: !Int
+  , errMessage :: !Text
+  , errData    :: !(Maybe Value)
+  } deriving Eq
+
+data JsonRpcException
+    = ParsingException String
+    | CallException RpcError
+    deriving (Eq, Show)
+
+instance Show RpcError where
+    show (RpcError code msg dat) =
+        "JSON-RPC error " ++ show code ++ ": " ++ unpack msg
+         ++ ". Data: " ++ show dat
+
+instance FromJSON RpcError where
+    parseJSON = withObject "JSON-RPC error object" $
+        \v -> RpcError <$> v .: "code"
+                       <*> v .: "message"
+                       <*> v .:? "data"
+
+
+instance Exception JsonRpcException

--- a/src/Network/JsonRpc/TinyClient.hs
+++ b/src/Network/JsonRpc/TinyClient.hs
@@ -31,14 +31,13 @@ module Network.JsonRpc.TinyClient (
   ) where
 
 import           Control.Applicative            ((<|>))
-import           Control.Exception              (Exception)
 import           Control.Monad                  ((<=<))
 import           Control.Monad.Catch            (MonadThrow, throwM)
 import           Control.Monad.IO.Class         (MonadIO, liftIO)
 import           Control.Monad.Reader           (MonadReader, ask)
 import           Data.Aeson
 import           Data.ByteString.Lazy           (ByteString)
-import           Data.Text                      (Text, unpack)
+import           Data.Text                      (Text)
 import           Network.Ethereum.Web3.Logging
 import           Network.Ethereum.Web3.Provider
 import           Network.HTTP.Client            (Manager,
@@ -47,6 +46,7 @@ import           Network.HTTP.Client            (Manager,
                                                  requestBody, requestHeaders,
                                                  responseBody)
 import           System.Random                  (randomIO)
+import           Network.JsonRpc.Exceptions
 
 instance FromJSON a => Remote Web3 (Web3 a)
 
@@ -78,23 +78,7 @@ instance FromJSON Response where
             \v -> Response <$>
                 (Right <$> v .: "result" <|> Left <$> v .: "error")
 
--- | JSON-RPC error message
-data RpcError = RpcError
-  { errCode    :: !Int
-  , errMessage :: !Text
-  , errData    :: !(Maybe Value)
-  } deriving Eq
 
-instance Show RpcError where
-    show (RpcError code msg dat) =
-        "JSON-RPC error " ++ show code ++ ": " ++ unpack msg
-         ++ ". Data: " ++ show dat
-
-instance FromJSON RpcError where
-    parseJSON = withObject "JSON-RPC error object" $
-        \v -> RpcError <$> v .: "code"
-                       <*> v .: "message"
-                       <*> v .:? "data"
 
 -- | Typeclass for JSON-RPC monad base.
 --
@@ -161,13 +145,6 @@ call m r = do
         resp <- responseBody <$> liftIO (httpLbs request' manager)
         liftIO . unWeb3Logger logger $ W3LMJsonRPCRawResponse rid resp
         return resp
-
-data JsonRpcException
-    = ParsingException String
-    | CallException RpcError
-    deriving (Eq, Show)
-
-instance Exception JsonRpcException
 
 decodeResponse :: (MonadThrow m, FromJSON a)
                => ByteString

--- a/web3.cabal
+++ b/web3.cabal
@@ -67,6 +67,7 @@ library
                      , Network.Ethereum.Contract.Event.SingleFilter
                      , Network.Ethereum.Contract.Event.Common
                      , Network.Ethereum.Contract.Method
+                     , Network.JsonRpc.Exceptions
                      , Network.JsonRpc.TinyClient
                      , Data.String.Extra
   build-depends:       base                 >4.9       && <4.12


### PR DESCRIPTION
It appears that even though there are provisions in the web3 error type, that all json rpc exceptions are piggy backing on the IO exception system. This fix adds a unification step in the runWeb3With' function so that the exceptions generated by JsonRPC are marshalled into the larger Web3Error type. We have run into this several times and we hacked around it in our client code. I figured this would be a valuable change to upstream. It doesn't change any of the API, it simply makes it such that all errors are being propagated via the same mechanism, rather than having some errors coming through Either/Except, and others coming from the IO exception system.